### PR TITLE
Sklekena/edge flip

### DIFF
--- a/src/student/meshedit.cpp
+++ b/src/student/meshedit.cpp
@@ -75,9 +75,62 @@ std::optional<Halfedge_Mesh::VertexRef> Halfedge_Mesh::collapse_face(Halfedge_Me
     flipped edge.
 */
 std::optional<Halfedge_Mesh::EdgeRef> Halfedge_Mesh::flip_edge(Halfedge_Mesh::EdgeRef e) {
+    // bail if is boundary edge
+    if(e->on_boundary()) return std::nullopt;
+    // get the origin verts
+    // get the destination verts
+    // get subject half edges
+    // get the next half edges
+    // get next next half edges
+    auto he1 = e->halfedge();
+    auto he2 = he1->twin();
+    auto origin1 = he1->next()->vertex();
+    auto origin2 = he2->next()->vertex();
+    auto hn1 = he1->next();
+    auto hn2 = he2->next();
+    auto dest1 = hn1->next()->vertex();
+    auto dest2 = hn2->next()->vertex();
+    auto hnn1 = hn1->next();
+    auto hnn2 = hn2->next();
+    // search for half edge to origin1 => founde
+    auto backhn1 = hn1;
+    while (backhn1->vertex() != origin2) {
+        backhn1 = backhn1->next();
+	}
+    // search for half edge to origin2
+    auto backhn2 = hn2;
+    while(backhn2->vertex() != origin1) {
+        backhn2 = backhn2->next();
+    }
+    
+    // begin CCW rotation
 
-    (void)e;
-    return std::nullopt;
+    // set current half edge to destination vertex
+    // set twin to destination vertex
+    // set current half edge next to destination next (next's next)
+    // set current half edge twin next to destination next (next's next)
+    // set next next to twin
+    // twin next to destination 2 next (twin next's next)
+    // set twin next next to current half edge
+    he1->vertex() = dest1;
+    he2->vertex() = dest2;
+    he1->next() = hnn1;
+    he2->next() = hnn2;
+    hn1->next() = he2;
+    hn2->next() = he1;
+
+    // set to founde twin to twin next
+    backhn1->next() = hn2;
+    // set to current half edge next
+    backhn2->next() = hn1;
+    // set face to know value
+    // set twin face to know value
+    he1->face()->halfedge() = he1;
+    he2->face()->halfedge() = he2;
+
+    // set origin1/2 half edge to outgoing half edge 
+    
+    return std::optional<Halfedge_Mesh::EdgeRef>(e);
 }
 
 /*

--- a/src/student/meshedit.cpp
+++ b/src/student/meshedit.cpp
@@ -84,22 +84,22 @@ std::optional<Halfedge_Mesh::EdgeRef> Halfedge_Mesh::flip_edge(Halfedge_Mesh::Ed
     // get next next half edges
     auto he1 = e->halfedge();
     auto he2 = he1->twin();
-    auto origin1 = he1->next()->vertex();
-    auto origin2 = he2->next()->vertex();
     auto hn1 = he1->next();
     auto hn2 = he2->next();
-    auto dest1 = hn1->next()->vertex();
-    auto dest2 = hn2->next()->vertex();
+    auto origin1 = hn1->vertex();
+    auto origin2 = hn2->vertex();
     auto hnn1 = hn1->next();
     auto hnn2 = hn2->next();
+    auto dest1 = hnn1->vertex();
+    auto dest2 = hnn2->vertex();
     // search for half edge to origin1 => founde
-    auto backhn1 = hn1;
-    while (backhn1->vertex() != origin2) {
+    auto backhn1 = hnn1;
+    while(backhn1->next() != he1) {
         backhn1 = backhn1->next();
-	}
+    }
     // search for half edge to origin2
-    auto backhn2 = hn2;
-    while(backhn2->vertex() != origin1) {
+    auto backhn2 = hnn2;
+    while(backhn2->next() != he2) {
         backhn2 = backhn2->next();
     }
     
@@ -112,8 +112,8 @@ std::optional<Halfedge_Mesh::EdgeRef> Halfedge_Mesh::flip_edge(Halfedge_Mesh::Ed
     // set next next to twin
     // twin next to destination 2 next (twin next's next)
     // set twin next next to current half edge
-    he1->vertex() = dest1;
-    he2->vertex() = dest2;
+    he1->vertex() = dest2;
+    he2->vertex() = dest1;
     he1->next() = hnn1;
     he2->next() = hnn2;
     hn1->next() = he2;
@@ -128,8 +128,9 @@ std::optional<Halfedge_Mesh::EdgeRef> Halfedge_Mesh::flip_edge(Halfedge_Mesh::Ed
     he1->face()->halfedge() = he1;
     he2->face()->halfedge() = he2;
 
-    // set origin1/2 half edge to outgoing half edge 
-    
+    // ensure half edge points to face
+    hn1->face() = he2->face();
+    hn2->face() = he1->face();
     return std::optional<Halfedge_Mesh::EdgeRef>(e);
 }
 


### PR DESCRIPTION
Edge rotation.

Algo, grab related elements associated with rotation origin verts and destination verts. N-gon shapes are account for by walking by halfedge->next till last halfedge to connect it to different next, adding a new edge to the face. Boundaries excluded.